### PR TITLE
Fix MySQL support.

### DIFF
--- a/src/main/java/eu/pb4/banhammer/BanHammerMod.java
+++ b/src/main/java/eu/pb4/banhammer/BanHammerMod.java
@@ -86,6 +86,9 @@ public class BanHammerMod implements ModInitializer {
 
 				LOGGER.error("Couldn't connect to database! Stopping server...");
 				server.stop(false);
+			} catch (ClassNotFoundException e) {
+				LOGGER.fatal("Could not load MySQL driver! Stopping server...");
+				server.stop(false);
 			}
 
 			IMPORTERS.put("vanilla", new VanillaImport());

--- a/src/main/java/eu/pb4/banhammer/database/MySQLDatabase.java
+++ b/src/main/java/eu/pb4/banhammer/database/MySQLDatabase.java
@@ -4,7 +4,9 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 
 public class MySQLDatabase extends AbstractSQLDatabase {
-    public MySQLDatabase(String address, String database, String username, String password) throws SQLException {
+    public MySQLDatabase(String address, String database, String username, String password) throws SQLException, ClassNotFoundException {
+        Class.forName("com.mysql.cj.jdbc.Driver");
+    
         conn = DriverManager.getConnection("jdbc:mysql://" + address + "/" + database, username, password);
         stat = conn.createStatement();
 


### PR DESCRIPTION
Currently, BanHammer does not load the MySQL driver when connecting; this leads to an exception during server load.
```
[13:37:00] [Server thread/INFO]: [STDERR]: java.sql.SQLException: No suitable driver found for jdbc:mysql://localhost:3306/minecraft
[13:37:00] [Server thread/INFO]: [STDERR]: 	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:702)
[13:37:00] [Server thread/INFO]: [STDERR]: 	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:228)
[13:37:00] [Server thread/INFO]: [STDERR]: 	at eu.pb4.banhammer.database.MySQLDatabase.<init>(MySQLDatabase.java:8)
[13:37:00] [Server thread/INFO]: [STDERR]: 	at eu.pb4.banhammer.BanHammerMod.onServerStarting(BanHammerMod.java:78)
[13:37:00] [Server thread/INFO]: [STDERR]: 	at net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents.lambda$static$0(ServerLifecycleEvents.java:37)
[13:37:00] [Server thread/INFO]: [STDERR]: 	at net.minecraft.server.MinecraftServer.handler$bch000$beforeSetupServer(MinecraftServer.java:6802)
[13:37:00] [Server thread/INFO]: [STDERR]: 	at net.minecraft.server.MinecraftServer.method_29741(MinecraftServer.java:670)
[13:37:00] [Server thread/INFO]: [STDERR]: 	at net.minecraft.server.MinecraftServer.method_29739(MinecraftServer.java:270)
[13:37:00] [Server thread/INFO]: [STDERR]: 	at java.base/java.lang.Thread.run(Thread.java:831)
[13:37:00] [Server thread/ERROR]: Couldn't connect to database! Stopping server...
```
This PR solves the issue by loading the driver in the constructor  of `MySQLDatabase`.