### PR TITLE
Small Tweaks/Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,11 @@ You can find this config in `config/banhammer/config.json`.
   "punishmentsAreSilent": false,             // Makes all punishments silent
   "storeAllPunishmentsInHistory": true,      // Stores all punishments in additional database table
   "muteBlockedCommands": [                   // List of commands blocked to muted players
+    "me",
     "msg",
-    "me"
+    "tell",
+    "w",
+    "teammsg"
   ],
   "standardBanPlayersWithBannedIps": false,  // Gives users standard bans, when they are ip banned
   "autoBansFromIpBansAreSilent": true,       // Makes autobans from ip ban silent

--- a/src/main/java/eu/pb4/banhammer/api/PunishmentData.java
+++ b/src/main/java/eu/pb4/banhammer/api/PunishmentData.java
@@ -187,6 +187,7 @@ public sealed class PunishmentData permits PunishmentData.Synced {
         list.put("expiration_date", Text.literal(this.getFormattedExpirationDate()));
         list.put("expiration_time", Text.literal(this.getFormattedExpirationTime()));
         list.put("banned", this.playerDisplayName.copy());
+        list.put("banned_name", Text.literal(this.playerName));
         list.put("banned_uuid", Text.literal(this.playerUUID.toString()));
 
         return list;
@@ -201,6 +202,7 @@ public sealed class PunishmentData permits PunishmentData.Synced {
         list.put("expiration_date", this.getFormattedExpirationDate());
         list.put("expiration_time", this.getFormattedExpirationTime());
         list.put("banned", this.playerDisplayName.getString());
+        list.put("banned_name", this.playerName);
         list.put("banned_uuid", this.playerUUID.toString());
 
         return list;

--- a/src/main/java/eu/pb4/banhammer/impl/config/data/ConfigData.java
+++ b/src/main/java/eu/pb4/banhammer/impl/config/data/ConfigData.java
@@ -7,7 +7,7 @@ public final class ConfigData {
 
     public boolean punishmentsAreSilent = false;
     public boolean storeAllPunishmentsInHistory = true;
-    public List<String> muteBlockedCommands = Arrays.asList("msg", "me");
+    public List<String> muteBlockedCommands = Arrays.asList("me", "msg", "tell", "w", "teammsg");
     public String defaultTempPunishmentDurationLimit = "-1";
     public HashMap<String, String> permissionTempLimit = exampleTempLimit();
 

--- a/src/main/java/eu/pb4/banhammer/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/eu/pb4/banhammer/mixin/ServerPlayNetworkHandlerMixin.java
@@ -55,7 +55,7 @@ public abstract class ServerPlayNetworkHandlerMixin {
             var punishment = punishments.get(0);
 
             int x = string.indexOf(" ");
-            String rawCommand = string.substring(1, x != -1 ? x : string.length());
+            String rawCommand = string.substring(0, x != -1 ? x : string.length());
             for (String command : ConfigManager.getConfig().mutedCommands) {
                 if (rawCommand.startsWith(command)) {
                     ci.cancel();


### PR DESCRIPTION
Some small tweaks:

- Adds a `banned_name` placeholder (Would have loved to add a similar placeholder for the operator, but didn't seem possible without some kind of refactor)
- Fixed blocked commands (when muted) not working. The package no longer includes leading slashes, so index 0 instead of 1 is needed
- Added all vanilla commands (that I know of), which allow a non-OP player to communicate, to the blocked commands list