### PR TITLE
Fix webhooks

### DIFF
--- a/src/main/java/eu/pb4/banhammer/impl/discord/DiscordWebhookMessage.java
+++ b/src/main/java/eu/pb4/banhammer/impl/discord/DiscordWebhookMessage.java
@@ -20,7 +20,7 @@ public final class DiscordWebhookMessage {
     public boolean tts = false;
     public List<Embed> embeds;
     @SerializedName("allowed_mentions")
-    public boolean allowedMentions = false;
+    public AllowedMentions allowedMentions = new AllowedMentions();
 
     public DiscordWebhookMessage content(String content) {
         this.content = content;
@@ -48,6 +48,10 @@ public final class DiscordWebhookMessage {
 
     public String toJson() {
         return GSON.toJson(this);
+    }
+
+    public static class AllowedMentions {
+        public String[] parse = new String[]{};
     }
 
     public static class Embed {


### PR DESCRIPTION
The webhooks `allowed_mentions` is incorrect. According to [discords docs](https://discord.com/developers/docs/resources/channel#allowed-mentions-object) it should be an object, but it is a boolean here.
This PR changes the allowed_mentions field to the following format, which suppresses all mentions:
```json
"allowed_mentions": {
  "parse": []
}
```